### PR TITLE
Support a secure hash function for file validation

### DIFF
--- a/nataili/model_manager/base.py
+++ b/nataili/model_manager/base.py
@@ -312,9 +312,13 @@ class BaseModelManager:
             logger.debug(f"Expected: {file_details['md5sum']}")
             if file_details["md5sum"] != md5_file_hash:
                 return False
+            else:
+                return True
 
-        # If no hashes available, return False
-        return False
+        # If no hashes available, return True for now
+        # THIS IS A SECURITY RISK, EVENTUALLY WE SHOULD RETURN FALSE
+        # But currently not all models specify hashes
+        return True
 
     def check_file_available(self, file_path):
         """

--- a/nataili/model_manager/base.py
+++ b/nataili/model_manager/base.py
@@ -206,7 +206,8 @@ class BaseModelManager:
                 return False
         return True
 
-    def get_file_hash(self, file_name):
+    @staticmethod
+    def get_file_md5sum_hash(file_name):
         # Bail out if the source file doesn't exist
         if not os.path.isfile(file_name):
             return
@@ -245,25 +246,75 @@ class BaseModelManager:
 
         return md5_hash
 
+    @staticmethod
+    def get_file_sha256_hash(file_name):
+        if not os.path.isfile(file_name):
+            raise FileNotFoundError("No file {}".format(file_name))
+
+        # Check if we have a cached sha256 hash for the source file
+        # and use that unless our source file is newer than our hash
+        sha256_file = f"{os.path.splitext(file_name)[0]}.sha256"
+        source_timestamp = os.path.getmtime(file_name)
+        if os.path.isfile(sha256_file):
+            hash_timestamp = os.path.getmtime(sha256_file)
+        else:
+            hash_timestamp = 0
+        if hash_timestamp > source_timestamp:
+            # Use our cached hash
+            with open(sha256_file, "rt") as handle:
+                sha256_hash = handle.read().split()[0]
+            return sha256_hash
+
+        # Calculate the hash of the source file
+        with open(file_name, "rb") as file_to_check:
+            file_hash = hashlib.sha256()
+            while True:
+                chunk = file_to_check.read(8192)
+                if not chunk:
+                    break
+                file_hash.update(chunk)
+        sha256_hash = file_hash.hexdigest()
+
+        # Cache this sha256 hash we just calculated. Use sha256sum format files
+        # so we can also use OS tools to manipulate these md5 files
+        try:
+            with open(sha256_file, "wt") as handle:
+                handle.write(f"{sha256_hash} *{os.path.basename(sha256_file)}")
+        except (OSError, PermissionError):
+            logger.debug("Could not write to sha256sum file, ignoring")
+
+        return sha256_hash
+
     def validate_file(self, file_details):
         """
         :param file_details: A single file from the model's files list
         Checks if the file exists and if the checksum is correct
         Returns True if the file is valid, False otherwise
         """
-        if "md5sum" in file_details:
-            full_path = f"{self.path}/{file_details['path']}"
-            logger.debug(f"Getting md5sum of {full_path}")
-            file_hash = self.get_file_hash(full_path)
-            logger.debug(f"md5sum: {file_hash}")
-            logger.debug(f"Expected: {file_details['md5sum']}")
-            if file_details["md5sum"] != file_hash:
+        full_path = f"{self.path}/{file_details['path']}"
+
+        # Default to sha256 hashes
+        if "sha256sum" in file_details:
+            logger.debug(f"Getting sha256sum of {full_path}")
+            sha256_file_hash = self.get_file_sha256_hash(full_path)
+            logger.debug(f"sha256sum: {sha256_file_hash}")
+            logger.debug(f"Expected: {file_details['sha256sum']}")
+            if file_details["sha256sum"] != sha256_file_hash:
                 return False
             else:
                 return True
-        else:
-            logger.debug("No md5sum provided")
-            return True
+
+        # If sha256 is not available, fall back to md5
+        if "md5sum" in file_details:
+            logger.debug(f"Getting md5sum of {full_path}")
+            md5_file_hash = self.get_file_md5sum_hash(full_path)
+            logger.debug(f"md5sum: {md5_file_hash}")
+            logger.debug(f"Expected: {file_details['md5sum']}")
+            if file_details["md5sum"] != md5_file_hash:
+                return False
+
+        # If no hashes available, return False
+        return False
 
     def check_file_available(self, file_path):
         """

--- a/scripts/test_file_hashes.py
+++ b/scripts/test_file_hashes.py
@@ -1,0 +1,36 @@
+import os
+import re
+
+from nataili.model_manager.base import BaseModelManager
+
+DIRECTORY = "test_imgs/"
+FILEPATTERN = "^.*\.(md5|sha256)$"
+
+
+class TestImageHashes:
+    def __init__(self, filename: str, md5hash: str, sha256hash: str):
+        self.filename = filename
+        self.md5hash = md5hash
+        self.sha256hash = sha256hash
+
+
+TEST_HASHES = [
+    TestImageHashes("bag.png",
+                    md5hash="1a443b1f39203a9629c5ad4088915050",
+                    sha256hash="667155baed8357af22adb5738a33e1063b58149bedb532b28a1a7295b28d371c"),
+    TestImageHashes("bird.png",
+                    md5hash="f58b5d829aaa23bc4efa0e4420c99760",
+                    sha256hash="cad49fc7d3071b2bcd078bc8dde365f8fa62eaa6d43705fd50c212794a3aac35"),
+]
+
+# Calculate hashes, assert equals
+for h in TEST_HASHES:
+    calculated_md5sum = BaseModelManager.get_file_md5sum_hash(DIRECTORY + h.filename)
+    calculated_sha256sum = BaseModelManager.get_file_sha256_hash(DIRECTORY + h.filename)
+    assert calculated_md5sum == h.md5hash
+    assert calculated_sha256sum == h.sha256hash
+
+# Remove cached hash files
+for f in os.listdir(DIRECTORY):
+    if re.search(FILEPATTERN, f):
+        os.remove(os.path.join(DIRECTORY, f))


### PR DESCRIPTION
Nataili currently uses MD5 for its hashing algorithm, which is a security risk. The MD5 algorithm is no longer considered resistant to collisions [as of 2010](https://www.kb.cert.org/vuls/id/836068).

This security risk is probably acceptable in many cases, but it should not be considered acceptable for distributing .cpkt files. Checkpoint files are expected to be many GBs of random-looking data, which is the **ideal** file contents to distribute malware along with GBs of random data that happens to generate an MD5 collision. 

A move to SHA256 could greatly help reduce this threat. SHA256 is secure for untrusted data, commonly used, and available in standard library. SHA256 is also implemented by HuggingFace, so perhaps there could be some code written to check calculated hashes against HuggingFace hashes when hashes are not available for a model downloaded from HF. There may be some debate over whether Nataili should use [a faster hash function like BLAKE3](https://jolynch.github.io/posts/use_fast_data_algorithms/), but BLAKE3 is not in the standard library and I didn't want to introduce any new dependencies.

This PR does not break current behaviour. It does not require a file to have an associated hash (which is a security risk), and also falls back to MD5 when SHA256 is not available. In the future perhaps this behaviour can be changed to be more strict.

Unit tests are provided but are not comprehensive. I did not see much testing around the model manager code.