### PR TITLE
Add better error handling around corrupt model cache files

### DIFF
--- a/nataili/__init__.py
+++ b/nataili/__init__.py
@@ -6,3 +6,10 @@ enable_local_ray_temp = Switch()
 disable_progress = Switch()
 disable_download_progress = Switch()
 enable_ray_alternative = Switch()
+
+
+class InvalidModelException(Exception):
+    pass
+
+class InvalidModelCacheException(InvalidModelException):
+    pass

--- a/nataili/__init__.py
+++ b/nataili/__init__.py
@@ -11,5 +11,6 @@ enable_ray_alternative = Switch()
 class InvalidModelException(Exception):
     pass
 
+
 class InvalidModelCacheException(InvalidModelException):
     pass

--- a/nataili/model_manager/super.py
+++ b/nataili/model_manager/super.py
@@ -275,6 +275,9 @@ class ModelManager:
         if self.controlnet is not None and model_name in self.controlnet.models:
             self.controlnet.unload_model(model_name)
             del self.loaded_models[model_name]
+        # Also remove from super() model list
+        if model_name in self.loaded_models:
+            del self.loaded_models[model_name]
 
     def get_loaded_models_names(self, string=False):
         """

--- a/nataili/stable_diffusion/compvis.py
+++ b/nataili/stable_diffusion/compvis.py
@@ -42,6 +42,7 @@ from ldm.models.diffusion.ddpm import LatentDiffusion
 from ldm.models.diffusion.ddpm_edit import LatentDiffusion as LatentDiffusionPix2Pix
 from ldm.models.diffusion.kdiffusion import CFGMaskedDenoiser, KDiffusionSampler
 from ldm.models.diffusion.plms import PLMSSampler
+from nataili import InvalidModelCacheException
 from nataili.model_manager.controlnet import ControlNetModelManager
 from nataili.stable_diffusion.annotation import (
     HED,
@@ -197,9 +198,12 @@ class CompVis:
         ] = None,
         init_as_control: bool = False,
     ):
-        model_context = (
-            load_from_plasma(self.model["model"], self.model["device"]) if not self.disable_voodoo else nullcontext()
-        )
+        try:
+            model_context = (
+                load_from_plasma(self.model["model"], self.model["device"]) if not self.disable_voodoo else nullcontext()
+            )
+        except InvalidModelCacheException:
+            raise
         with model_context as model:
             if self.disable_voodoo:
                 model: Union[LatentDiffusion, LatentDiffusionPix2Pix, ControlLDM] = self.model["model"]

--- a/nataili/stable_diffusion/compvis.py
+++ b/nataili/stable_diffusion/compvis.py
@@ -200,7 +200,9 @@ class CompVis:
     ):
         try:
             model_context = (
-                load_from_plasma(self.model["model"], self.model["device"]) if not self.disable_voodoo else nullcontext()
+                load_from_plasma(self.model["model"], self.model["device"])
+                if not self.disable_voodoo
+                else nullcontext()
             )
         except InvalidModelCacheException:
             raise

--- a/nataili/stable_diffusion/compvis.py
+++ b/nataili/stable_diffusion/compvis.py
@@ -198,14 +198,9 @@ class CompVis:
         ] = None,
         init_as_control: bool = False,
     ):
-        try:
-            model_context = (
-                load_from_plasma(self.model["model"], self.model["device"])
-                if not self.disable_voodoo
-                else nullcontext()
-            )
-        except InvalidModelCacheException:
-            raise
+        model_context = (
+            load_from_plasma(self.model["model"], self.model["device"]) if not self.disable_voodoo else nullcontext()
+        )
         with model_context as model:
             if self.disable_voodoo:
                 model: Union[LatentDiffusion, LatentDiffusionPix2Pix, ControlLDM] = self.model["model"]

--- a/nataili/util/voodoo.py
+++ b/nataili/util/voodoo.py
@@ -27,7 +27,7 @@ from typing import Dict, List, Tuple, TypeVar
 import ray
 import torch
 
-from nataili import enable_local_ray_temp, enable_ray_alternative, InvalidModelCacheException
+from nataili import InvalidModelCacheException, enable_local_ray_temp, enable_ray_alternative
 from nataili.aitemplate import Model
 from nataili.util.logger import logger
 


### PR DESCRIPTION
It's super unlikely a model cache file becomes corrupt, but it can happen. Right now the horde worker will go into a death spiral and be forced into maintenance mode. This PR adds better error handling so we can more elegantly deal with that problem.

1. Automatically removes corrupt model cache files
2. Raises a sensible exception that can be dealt with in the horde worker by unloading the model to force it to re-cache
3. Fixes unload_model() so it unloads models in the super() class used by the horde worker.