### PR TITLE
Allow changing ray temp dir properly.

### DIFF
--- a/nataili/model_manager/super.py
+++ b/nataili/model_manager/super.py
@@ -18,6 +18,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import torch
 
 from nataili.util.logger import logger
+from nataili.util.voodoo import initialise_voodoo
 
 
 class ModelManager:
@@ -40,6 +41,7 @@ class ModelManager:
         codeformer: bool = False,
         controlnet: bool = False,
     ):
+        initialise_voodoo()
         if aitemplate:
             from nataili.model_manager.aitemplate import AITemplateModelManager
 


### PR DESCRIPTION
Ray was being initialised as soon as nataili was imported, this is way to soon. This changes it so ray is explicitly initialised when the model manager super class is instantiated, allowing us to correctly change the ray temp dir.